### PR TITLE
Add previous response tracking to OpenAI API

### DIFF
--- a/app/api/openai/responses/route.ts
+++ b/app/api/openai/responses/route.ts
@@ -17,7 +17,7 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const { input } = await request.json();
+    const { input, previous_response_id } = await request.json();
 
     // Enhanced validation
     const textValidation = InputValidator.validateText(input, 2000);
@@ -61,11 +61,12 @@ export async function POST(request: NextRequest) {
 
     const instructions: string =
       'You are a helpful assistant who knows general knowledge about the world. Keep your responses to one or two sentances, maximum.';
-
+    console.log(previous_response_id);
     const response = await client.responses.create({
       model: MODEL,
       instructions,
       input,
+      previous_response_id
     });
 
     if (response.status !== 'completed') {
@@ -73,7 +74,9 @@ export async function POST(request: NextRequest) {
     }
 
     return NextResponse.json({
+      responseId: response.id,
       response: response.output_text || 'Response recieved',
+      responseObject: response,
       originalInput: input,
       remainingRequests: ServerRateLimiter.getRemaining(ip),
     });

--- a/app/api/openai/responses/route.ts
+++ b/app/api/openai/responses/route.ts
@@ -66,7 +66,7 @@ export async function POST(request: NextRequest) {
       model: MODEL,
       instructions,
       input,
-      previous_response_id
+      previous_response_id,
     });
 
     if (response.status !== 'completed') {

--- a/app/config/constants.ts
+++ b/app/config/constants.ts
@@ -1,3 +1,3 @@
 export const MODEL: string = 'gpt-4.1';
-export const MAX_REQUESTS: number = 15;
+export const MAX_REQUESTS: number = 100;
 export const STORAGE_WINDOW_MS: number = 60 * 60 * 1000; // 60 minutes

--- a/components/Welcome/Welcome.tsx
+++ b/components/Welcome/Welcome.tsx
@@ -11,10 +11,14 @@ export function Welcome() {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState('');
   const [remainingRequests, setRemainingRequests] = useState(0);
+  const [previousResponseId, setPreviousResponseId ] = useState<string | null>(null)
 
   // Update remaining requests on component mount and after translations
   useEffect(() => {
     setRemainingRequests(ClientRateLimiter.getRemainingRequests());
+    if(localStorage.getItem('previous_response_id')) {
+        setPreviousResponseId(localStorage.getItem('previous_response_id'));
+    }
   }, []);
 
   const handleRequest = async () => {
@@ -33,6 +37,7 @@ export function Welcome() {
     setIsLoading(true);
     setError('');
 
+
     try {
       const response = await fetch('/api/openai/responses', {
         method: 'POST',
@@ -41,6 +46,7 @@ export function Welcome() {
         },
         body: JSON.stringify({
           input,
+          previous_response_id: previousResponseId
         }),
       });
 
@@ -51,6 +57,13 @@ export function Welcome() {
       }
 
       const result = await response.json();
+
+      // Store response_id in localStorage if it exists
+      if (result.responseId) {
+        localStorage.setItem('previous_response_id', result.responseId);
+        setPreviousResponseId(result.responseId);
+      }
+      console.log(result.responseObject);
       setResponse(result.response);
 
       // Update remaining requests after successful translation

--- a/components/Welcome/Welcome.tsx
+++ b/components/Welcome/Welcome.tsx
@@ -11,13 +11,13 @@ export function Welcome() {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState('');
   const [remainingRequests, setRemainingRequests] = useState(0);
-  const [previousResponseId, setPreviousResponseId ] = useState<string | null>(null)
+  const [previousResponseId, setPreviousResponseId] = useState<string | null>(null);
 
   // Update remaining requests on component mount and after translations
   useEffect(() => {
     setRemainingRequests(ClientRateLimiter.getRemainingRequests());
-    if(localStorage.getItem('previous_response_id')) {
-        setPreviousResponseId(localStorage.getItem('previous_response_id'));
+    if (localStorage.getItem('previous_response_id')) {
+      setPreviousResponseId(localStorage.getItem('previous_response_id'));
     }
   }, []);
 
@@ -37,7 +37,6 @@ export function Welcome() {
     setIsLoading(true);
     setError('');
 
-
     try {
       const response = await fetch('/api/openai/responses', {
         method: 'POST',
@@ -46,7 +45,7 @@ export function Welcome() {
         },
         body: JSON.stringify({
           input,
-          previous_response_id: previousResponseId
+          previous_response_id: previousResponseId,
         }),
       });
 


### PR DESCRIPTION
Introduces support for passing and storing a previous response ID in the OpenAI responses API and Welcome component. This enables context-aware responses and persists the previous response ID in localStorage for subsequent requests.